### PR TITLE
Inpainting pipeline fix

### DIFF
--- a/core/inference/LPW_SD.py
+++ b/core/inference/LPW_SD.py
@@ -1137,6 +1137,8 @@ class StableDiffusionLongPromptWeightingPipeline(StableDiffusionPipeline):
         callback: Optional[Callable[[int, int, torch.FloatTensor], None]] = None,
         is_cancelled_callback: Optional[Callable[[], bool]] = None,
         callback_steps: int = 1,
+        width: int = 512,
+        height: int = 512,
     ):
         r"""
         Function for inpaint.
@@ -1193,6 +1195,10 @@ class StableDiffusionLongPromptWeightingPipeline(StableDiffusionPipeline):
             callback_steps (`int`, *optional*, defaults to 1):
                 The frequency at which the `callback` function will be called. If not specified, the callback will be
                 called at every step.
+            width (`int`, *optional*, defaults to 512):
+                The width of the generated image.
+            height (`int`, *optional*, defaults to 512):
+                The height of the generated image.
         Returns:
             [`~pipelines.stable_diffusion.StableDiffusionPipelineOutput`] or `tuple`:
             [`~pipelines.stable_diffusion.StableDiffusionPipelineOutput`] if `return_dict` is True, otherwise a `tuple.
@@ -1217,4 +1223,6 @@ class StableDiffusionLongPromptWeightingPipeline(StableDiffusionPipeline):
             callback=callback,
             is_cancelled_callback=is_cancelled_callback,
             callback_steps=callback_steps,
+            width=width,
+            height=height,
         )

--- a/core/inference/pytorch.py
+++ b/core/inference/pytorch.py
@@ -321,7 +321,6 @@ class PyTorchStableDiffusion(InferenceModel):
         input_mask_image = convert_to_image(job.data.mask_image).convert("RGB")
         input_mask_image = ImageOps.invert(input_mask_image)
         input_mask_image = resize(input_mask_image, job.data.width, job.data.height)
-        input_mask_image.save("mask.png")
 
         total_images: List[Image.Image] = []
 

--- a/core/inference/pytorch.py
+++ b/core/inference/pytorch.py
@@ -320,7 +320,7 @@ class PyTorchStableDiffusion(InferenceModel):
 
         input_mask_image = convert_to_image(job.data.mask_image).convert("RGB")
         input_mask_image = ImageOps.invert(input_mask_image)
-        input_mask_image = resize(input_mask_image, job.data.height, job.data.width)
+        input_mask_image = resize(input_mask_image, job.data.width, job.data.height)
         input_mask_image.save("mask.png")
 
         total_images: List[Image.Image] = []
@@ -338,6 +338,8 @@ class PyTorchStableDiffusion(InferenceModel):
                 callback=inpaint_callback,
                 return_dict=False,
                 num_images_per_prompt=job.data.batch_size,
+                width=job.data.width,
+                height=job.data.height,
             )
 
             if not data:


### PR DESCRIPTION
 - Correct the inverted mask resizing parameters.
 - Pass width and height to diffusers inpainting pipeline to allow non-default input sizes.